### PR TITLE
[BE] 성향 매칭 테스트 질문지, 선택지 API 구현

### DIFF
--- a/src/main/java/com/_z/eum/matching/careerTest/controller/CareerTestController.java
+++ b/src/main/java/com/_z/eum/matching/careerTest/controller/CareerTestController.java
@@ -1,0 +1,35 @@
+package com._z.eum.matching.careerTest.controller;
+
+
+import com._z.eum.matching.careerTest.dto.Response.QuestionResponse;
+import com._z.eum.matching.careerTest.service.CareerTestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/careerTest")
+@Tag(name = "매칭 테스트 질문지, 선택지 API", description = "질문지, 선택지 조회 및 선택 결과 반환 기능 제공")
+public class CareerTestController {
+
+    private final CareerTestService careerTestService;
+
+    public CareerTestController(CareerTestService careerTestService){
+        this.careerTestService = careerTestService;
+    }
+
+    //모든 질문, 선택지 반환
+    @Operation(summary = "전체 질문, 선택지 조회", description = "모든 질문지에 대한 선택지를 제공함")
+    @GetMapping("/questions")
+    public ResponseEntity<List<QuestionResponse>> getQuestions() {
+        return ResponseEntity.ok(careerTestService.getAllQuestions());
+    }
+
+
+
+}

--- a/src/main/java/com/_z/eum/matching/careerTest/dto/Response/QuestionResponse.java
+++ b/src/main/java/com/_z/eum/matching/careerTest/dto/Response/QuestionResponse.java
@@ -1,0 +1,18 @@
+package com._z.eum.matching.careerTest.dto.Response;
+
+import org.w3c.dom.Text;
+
+import java.util.List;
+
+public record QuestionResponse(
+        Integer questionId,
+        String text,
+        int orderNo,
+        List<OptionResponse> options
+) {
+    public record OptionResponse(
+            Integer optionId,
+            String text,
+            int orderNo
+    ) {}
+}

--- a/src/main/java/com/_z/eum/matching/careerTest/entity/CareerTestOption.java
+++ b/src/main/java/com/_z/eum/matching/careerTest/entity/CareerTestOption.java
@@ -1,0 +1,26 @@
+package com._z.eum.matching.careerTest.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import jakarta.persistence.Id;
+import org.w3c.dom.Text;
+
+@Entity
+@Table(name = "career_test_option")
+@Getter
+@Setter
+public class CareerTestOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private CareerTestQuestion question;
+
+    private String text;
+    private int orderNo;
+
+    protected CareerTestOption(){}
+}

--- a/src/main/java/com/_z/eum/matching/careerTest/entity/CareerTestQuestion.java
+++ b/src/main/java/com/_z/eum/matching/careerTest/entity/CareerTestQuestion.java
@@ -1,0 +1,28 @@
+package com._z.eum.matching.careerTest.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "career_test_question")
+@Getter
+@Setter
+public class CareerTestQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String text;
+    private int orderNo;
+
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    @OrderBy("orderNo ASC")
+    private List<CareerTestOption> options = new ArrayList<>();
+
+
+    protected CareerTestQuestion(){}
+}

--- a/src/main/java/com/_z/eum/matching/careerTest/repository/CareerTestRepository.java
+++ b/src/main/java/com/_z/eum/matching/careerTest/repository/CareerTestRepository.java
@@ -1,0 +1,16 @@
+package com._z.eum.matching.careerTest.repository;
+
+import com._z.eum.matching.careerTest.entity.CareerTestQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CareerTestRepository extends JpaRepository<CareerTestQuestion,Integer> {
+
+    List<CareerTestQuestion> findAllByOrderByOrderNoAsc();
+
+}

--- a/src/main/java/com/_z/eum/matching/careerTest/service/CareerTestService.java
+++ b/src/main/java/com/_z/eum/matching/careerTest/service/CareerTestService.java
@@ -1,0 +1,47 @@
+package com._z.eum.matching.careerTest.service;
+
+import com._z.eum.matching.careerTest.dto.Response.QuestionResponse;
+import com._z.eum.matching.careerTest.entity.CareerTestQuestion;
+import com._z.eum.matching.careerTest.repository.CareerTestRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+public class CareerTestService {
+
+    private final CareerTestRepository careerTestRepository;
+
+    public CareerTestService(CareerTestRepository careerTestRepository){
+        this.careerTestRepository = careerTestRepository;
+    }
+
+
+    public List<QuestionResponse> getAllQuestions() {
+        List<CareerTestQuestion> questions = careerTestRepository.findAllByOrderByOrderNoAsc();
+
+        return questions.stream()
+                .map(q -> {
+
+                    List<QuestionResponse.OptionResponse> optionDtos = q.getOptions().stream()
+                            .map(o -> new QuestionResponse.OptionResponse(
+                                    o.getId(),
+                                    o.getText(),
+                                    o.getOrderNo()
+                            )).toList();
+
+
+                    return new QuestionResponse(
+                            q.getId(),
+                            q.getText(),
+                            q.getOrderNo(),
+                            optionDtos
+                    );
+                })
+                .toList();
+    }
+}
+
+
+


### PR DESCRIPTION
### 📌 PR 제목
매칭 테스트 질문지, 선택지 API 구현
---

### ✅ 작업 개요
- 성향 매칭 질문지 API 구현함
- 질문지에 맞는 순서에 맞게 선택지를 반환함 
- 관련 이슈 번호: Closes #3  


---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| API 추가 | 신규 API 추가 |
| DB 변경 | 엔티티 추가 |
<img width="1182" height="271" alt="스크린샷 2025-07-28 오후 4 29 13" src="https://github.com/user-attachments/assets/f56d1804-644c-4de9-981b-c588e9f2287b" />

---

### 📂 관련 파일 경로
- `src/matching/careerTest 폴더

---

### 🧪 테스트 및 검증
- [x] 질문지 번호 별 선택지 반환 스웨거 테스트함
---

### 📎 참고 자료
<img width="1518" height="156" alt="스크린샷 2025-07-28 오후 4 26 18" src="https://github.com/user-attachments/assets/b2f13c53-03c1-4a21-b996-29181d805044" />

---

### 📌 기타 공유사항


