### PR TITLE
[BE] 기술 매칭 테스트  API 구현 

### DIFF
--- a/src/main/java/com/_z/eum/matching/controller/CareerTestController.java
+++ b/src/main/java/com/_z/eum/matching/controller/CareerTestController.java
@@ -32,7 +32,6 @@ public class CareerTestController {
         return ResponseEntity.ok(exists);
     }
 
-
     //모든 질문, 선택지 반환
     @Operation(summary = "전체 질문, 선택지 조회", description = "모든 질문지에 대한 선택지를 제공함")
     @GetMapping("/careerTest")
@@ -40,12 +39,14 @@ public class CareerTestController {
         return ResponseEntity.ok(careerTestService.getAllQuestions());
     }
 
+    //사용자 기술 저장 후 결과 반환
     @PostMapping("/submit/{userId}")
     @Operation(summary = "응답 제출 및 추천 기술 저장", description = "사용자의 선택지 ID 리스트를 기반으로 추천 기술 10개를 저장하고 반환")
     public ResponseEntity<List<MatchResult>> submitTest(@PathVariable Integer userId, @RequestBody MatchRequest request) {
         return ResponseEntity.ok(careerTestService.processCareerTest(userId, request.optionIds()));
     }
 
+    //이미 저장된 결과 반환
     @GetMapping("/recommendations/{userId}")
     @Operation(summary = "저장된 추천 기술 반환", description = "사용자의 추천 기술 리스트 10개를 반환")
     public ResponseEntity<List<MatchResult>> getRecommendations(@PathVariable Integer userId) {

--- a/src/main/java/com/_z/eum/matching/controller/CareerTestController.java
+++ b/src/main/java/com/_z/eum/matching/controller/CareerTestController.java
@@ -24,6 +24,15 @@ public class CareerTestController {
         this.careerTestService = careerTestService;
     }
 
+    //검사 이력 조회
+    @GetMapping("/history/{userId}")
+    @Operation(summary = "사용자 검사 이력 조회", description = "해당 사용자가 이미 검사를 수행했는지 여부를 반환")
+    public ResponseEntity<Boolean> checkHistory(@PathVariable Integer userId) {
+        boolean exists = careerTestService.hasTakenTest(userId);
+        return ResponseEntity.ok(exists);
+    }
+
+
     //모든 질문, 선택지 반환
     @Operation(summary = "전체 질문, 선택지 조회", description = "모든 질문지에 대한 선택지를 제공함")
     @GetMapping("/careerTest")
@@ -31,12 +40,17 @@ public class CareerTestController {
         return ResponseEntity.ok(careerTestService.getAllQuestions());
     }
 
-    // 테스트 결과 10개 리스트 반환
-    @Operation(summary = "성향테스트 결과 조회 및 저장", description = "기술 순위 10개와 합산점수 제공함")
-    @PostMapping("/matchResult")
-    public ResponseEntity<List<MatchResult>> getMatchResult(@RequestBody MatchRequest matchRequest){
-        List<MatchResult> results = careerTestService.calculateTopSkills(matchRequest.optionIds());
-        return ResponseEntity.ok(results);
+    @PostMapping("/submit/{userId}")
+    @Operation(summary = "응답 제출 및 추천 기술 저장", description = "사용자의 선택지 ID 리스트를 기반으로 추천 기술 10개를 저장하고 반환")
+    public ResponseEntity<List<MatchResult>> submitTest(@PathVariable Integer userId, @RequestBody MatchRequest request) {
+        return ResponseEntity.ok(careerTestService.processCareerTest(userId, request.optionIds()));
     }
+
+    @GetMapping("/recommendations/{userId}")
+    @Operation(summary = "저장된 추천 기술 반환", description = "사용자의 추천 기술 리스트 10개를 반환")
+    public ResponseEntity<List<MatchResult>> getRecommendations(@PathVariable Integer userId) {
+        return ResponseEntity.ok(careerTestService.getSavedRecommendations(userId));
+    }
+
 
 }

--- a/src/main/java/com/_z/eum/matching/entity/CareerTestRecommendation.java
+++ b/src/main/java/com/_z/eum/matching/entity/CareerTestRecommendation.java
@@ -1,0 +1,33 @@
+package com._z.eum.matching.entity;
+
+
+import com._z.eum.skill.entity.SkillCategory;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "careerTestRecommendation")
+public class CareerTestRecommendation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private int score;
+
+    private int ranking;
+
+    private int skillId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "career_test_result_id")
+    private CareerTestResult careerTestResult;
+
+    public CareerTestRecommendation(CareerTestResult result, int skillId, int score, int ranking) {
+        this.careerTestResult = result;
+        this.skillId = skillId;
+        this.score = score;
+        this.ranking = ranking;
+    }
+}

--- a/src/main/java/com/_z/eum/matching/entity/CareerTestResult.java
+++ b/src/main/java/com/_z/eum/matching/entity/CareerTestResult.java
@@ -1,0 +1,34 @@
+package com._z.eum.matching.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "careerTestResult")
+public class CareerTestResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private  Integer userId;
+
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    private String summary;
+
+    @OneToMany(mappedBy = "careerTestResult", cascade = CascadeType.ALL)
+    private List<CareerTestRecommendation> recommendations = new ArrayList<>();
+
+    public CareerTestResult(Integer userId) {
+        this.userId = userId;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/_z/eum/matching/repository/CareerTestOptionSkillRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/CareerTestOptionSkillRepository.java
@@ -1,0 +1,29 @@
+package com._z.eum.matching.repository;
+
+import com._z.eum.matching.dto.Response.MatchResult;
+import com._z.eum.matching.entity.CareerTestOptionSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CareerTestOptionSkillRepository extends JpaRepository<CareerTestOptionSkill, Integer> {
+
+    @Query("""
+        SELECT new com._z.eum.matching.dto.Response.MatchResult(
+                    s.skill.id,
+                    s.skill.name,
+                    SUM(s.score)
+                )
+                FROM CareerTestOptionSkill s
+                JOIN s.option o
+                WHERE o.id IN :optionIds
+                GROUP BY s.skill.id, s.skill.name
+                ORDER BY SUM(s.score) DESC
+   
+    """)
+    List<MatchResult> findSkillScoresByOptionIds(@Param("optionIds") List<Integer> optionIds);
+}

--- a/src/main/java/com/_z/eum/matching/repository/CareerTestRecommendationRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/CareerTestRecommendationRepository.java
@@ -1,0 +1,12 @@
+package com._z.eum.matching.repository;
+
+import com._z.eum.matching.entity.CareerTestRecommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CareerTestRecommendationRepository extends JpaRepository<CareerTestRecommendation, Integer> {
+
+    // 추천 기술 10개 저장 및 조회
+    List<CareerTestRecommendation> findByCareerTestResultIdOrderByRankingAsc(Integer resultId);
+}

--- a/src/main/java/com/_z/eum/matching/repository/CareerTestRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/CareerTestRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Repository
 public interface CareerTestRepository extends JpaRepository<CareerTestQuestion,Integer> {
 
+    //질문지, 선택지 조회
     List<CareerTestQuestion> findAllByOrderByOrderNoAsc();
 
 }

--- a/src/main/java/com/_z/eum/matching/repository/CareerTestResultRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/CareerTestResultRepository.java
@@ -1,29 +1,15 @@
 package com._z.eum.matching.repository;
 
-import com._z.eum.matching.dto.Response.MatchResult;
-import com._z.eum.matching.entity.CareerTestOptionSkill;
+import com._z.eum.matching.entity.CareerTestResult;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
-@Repository
-public interface CareerTestResultRepository extends JpaRepository<CareerTestOptionSkill, Integer> {
+public interface CareerTestResultRepository extends JpaRepository<CareerTestResult, Integer> {
 
-    @Query("""
-        SELECT new com._z.eum.matching.dto.Response.MatchResult(
-                    s.skill.id,
-                    s.skill.name,
-                    SUM(s.score)
-                )
-                FROM CareerTestOptionSkill s
-                JOIN s.option o
-                WHERE o.id IN :optionIds
-                GROUP BY s.skill.id, s.skill.name
-                ORDER BY SUM(s.score) DESC
-   
-    """)
-    List<MatchResult> findSkillScoresByOptionIds(@Param("optionIds") List<Integer> optionIds);
+    //검사 이력 조회
+    boolean existsByUserId(Integer userId);
+
+    //가장 최근 검사 결과 조회
+    Optional<CareerTestResult> findTopByUserIdOrderByUpdatedAtDesc(Integer userId);
 }

--- a/src/main/java/com/_z/eum/matching/service/CareerTestService.java
+++ b/src/main/java/com/_z/eum/matching/service/CareerTestService.java
@@ -46,6 +46,7 @@ public class CareerTestService {
     }
 
 
+    //질문지, 선택지 반환
     public List<QuestionResponse> getAllQuestions() {
         List<CareerTestQuestion> questions = careerTestRepository.findAllByOrderByOrderNoAsc();
 
@@ -70,6 +71,7 @@ public class CareerTestService {
                 .toList();
     }
 
+    //신규 테스트 결과 저장 후 기술 리스트 반환
     public List<MatchResult> processCareerTest(Integer userId, List<Integer> optionIds) {
         List<MatchResult> results = careerTestOptionSkillRepository.findSkillScoresByOptionIds(optionIds)
                 .stream().limit(10).toList();
@@ -84,6 +86,7 @@ public class CareerTestService {
         return results;
     }
 
+    //저장된 결과 이력 조회 후 기술 리스트 반환
     public List<MatchResult> getSavedRecommendations(Integer userId) {
         CareerTestResult latestResult = careerTestResultRepository.findTopByUserIdOrderByUpdatedAtDesc(userId)
                 .orElseThrow(() -> new NoSuchElementException("검사 결과가 없습니다"));

--- a/src/main/java/com/_z/eum/matching/service/CareerTestService.java
+++ b/src/main/java/com/_z/eum/matching/service/CareerTestService.java
@@ -2,22 +2,47 @@ package com._z.eum.matching.service;
 
 import com._z.eum.matching.dto.Response.QuestionResponse;
 import com._z.eum.matching.entity.CareerTestQuestion;
+import com._z.eum.matching.entity.CareerTestRecommendation;
+import com._z.eum.matching.entity.CareerTestResult;
+import com._z.eum.matching.repository.CareerTestRecommendationRepository;
 import com._z.eum.matching.repository.CareerTestRepository;
-import com._z.eum.matching.repository.CareerTestResultRepository;
+import com._z.eum.matching.repository.CareerTestOptionSkillRepository;
 import com._z.eum.matching.dto.Response.MatchResult;
+import com._z.eum.matching.repository.CareerTestResultRepository;
+import com._z.eum.skill.entity.SkillCategory;
+import com._z.eum.skill.repository.SkillRepository;
 import org.springframework.stereotype.Service;
 
+import javax.swing.*;
+import java.util.Comparator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 public class CareerTestService {
 
     private final CareerTestRepository careerTestRepository;
+    private final CareerTestOptionSkillRepository careerTestOptionSkillRepository;
+    private final CareerTestRecommendationRepository careerTestRecommendationRepository;
     private final CareerTestResultRepository careerTestResultRepository;
+    private final SkillRepository skillRepository;
 
-    public CareerTestService(CareerTestRepository careerTestRepository, CareerTestResultRepository careerTestResultRepository) {
-        this.careerTestResultRepository = careerTestResultRepository;
+    public CareerTestService(CareerTestRepository careerTestRepository,
+                             CareerTestOptionSkillRepository careerTestOptionSkillRepository,
+                             CareerTestRecommendationRepository careerTestRecommendationRepository,
+                             CareerTestResultRepository careerTestResultRepository,
+                             SkillRepository skillRepository) {
+
+        this.careerTestOptionSkillRepository = careerTestOptionSkillRepository;
         this.careerTestRepository = careerTestRepository;
+        this.careerTestRecommendationRepository = careerTestRecommendationRepository;
+        this.careerTestResultRepository = careerTestResultRepository;
+        this.skillRepository = skillRepository;
+    }
+
+    //검사 이력 조회
+    public boolean hasTakenTest(Integer userId) {
+        return careerTestResultRepository.existsByUserId(userId);
     }
 
 
@@ -45,10 +70,27 @@ public class CareerTestService {
                 .toList();
     }
 
-    public List<MatchResult> calculateTopSkills(List<Integer> optionIds) {
-        return careerTestResultRepository.findSkillScoresByOptionIds(optionIds)
-                .stream()
-                .limit(10)
+    public List<MatchResult> processCareerTest(Integer userId, List<Integer> optionIds) {
+        List<MatchResult> results = careerTestOptionSkillRepository.findSkillScoresByOptionIds(optionIds)
+                .stream().limit(10).toList();
+
+        CareerTestResult result = careerTestResultRepository.save(new CareerTestResult(userId));
+
+        int rank = 1;
+        for (MatchResult r : results) {
+            careerTestRecommendationRepository.save(new CareerTestRecommendation(result, r.skillId(), (int) r.totalScore(), rank++));
+        }
+
+        return results;
+    }
+
+    public List<MatchResult> getSavedRecommendations(Integer userId) {
+        CareerTestResult latestResult = careerTestResultRepository.findTopByUserIdOrderByUpdatedAtDesc(userId)
+                .orElseThrow(() -> new NoSuchElementException("검사 결과가 없습니다"));
+
+        return latestResult.getRecommendations().stream()
+                .sorted(Comparator.comparingInt(CareerTestRecommendation::getRanking))
+                .map(r -> new MatchResult(r.getSkillId(), skillRepository.findById(r.getSkillId()).orElseThrow().getName(),r.getScore()))
                 .toList();
     }
 }


### PR DESCRIPTION
### 📌 PR 제목
> Career Matching 테스트 API 명세 및 기능 설명
---

### ✅ 작업 개요
-  전체 질문, 선택지 조회
- 응답 제출 및 추천 기술 저장, 반환
-  저장된 추천 기술 반환
- 사용자 검사 이력 조회
- 관련 이슈 번호: Closes #8 

---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| API 추가/변경 | 신규 API 추가 |
| 로직 수정 | 기술 점수 계산 후 DB에 저장 후 반환하도록 수정 |
| 기타 | 리팩토링 |

---

### 📂 관련 파일 경로
- `src/main/java/com/_z/eum/matching

---

### 🧪 테스트 및 검증
- [x] Swagger로 직접 테스트 완료  

---

### 🙋 리뷰 포인트
- 사용자 검사 이력 확인 -> 이력 없으면 질문지/선택지 API -> 응답값 제출 및 결과 반환 
- 사용자 검사 이력 확인 -> 이력 있으면 이전 이력 불러오기 

---

### 📎 참고 자료
1.  api/matching/careerTest
- [GET] 전체 질문, 선택지 조회
- 성향 테스트를 구성하는 모든 질문지와 해당 선택지 리스트를 순서대로 반환

2. api/matching/submit/{userId}
- [POST] 응답 제출 및 추천 기술 저장
- 사용자가 선택한 선택지들의 ID 리스트를 전송하면,
내부적으로 기술 점수를 합산하여 상위 10개의 추천 기술을 저장합
- career_test_result와 career_test_recommendation 테이블에 결과가 저장

3.  /api/matching/recommendations/{userId}
- [GET] 저장된 추천 기술 반환
- 이전에 제출된 테스트 결과가 있다면, 해당 사용자의 최근 검사 결과에 따른 추천 기술 10개를 반환

4. /api/matching/history/{userId}
- [GET] 사용자 검사 이력 조회
- 해당 사용자가 기존에 검사를 수행한 적이 있는지 여부를 boolean으로 반환

<img width="1486" height="324" alt="스크린샷 2025-08-05 오전 1 33 14" src="https://github.com/user-attachments/assets/f23576e3-e084-478a-b8a3-06e858e94b9b" />



---

### 📌 기타 공유사항
- FE 흐름은 리뷰 포인트 참고!!

