### PR TITLE
[BE] 사용자 검사 이력 조회 500번대 에러 해결

### DIFF
--- a/src/main/java/com/_z/eum/career/controller/CareerTestController.java
+++ b/src/main/java/com/_z/eum/career/controller/CareerTestController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/matching")
-@Tag(name = "매칭 테스트 질문지, 선택지 API", description = "질문지, 선택지 조회 및 선택 결과 반환 기능 제공")
+@Tag(name = "매칭 테스트 API", description = "질문지, 선택지 조회 및 선택 결과 반환 기능 제공")
 public class CareerTestController {
 
     private final CareerTestService careerTestService;

--- a/src/main/java/com/_z/eum/career/entity/CareerTestRecommendation.java
+++ b/src/main/java/com/_z/eum/career/entity/CareerTestRecommendation.java
@@ -3,10 +3,12 @@ package com._z.eum.career.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "careerTestRecommendation")
+@NoArgsConstructor
+@Table(name = "career_test_recommendation")
 public class CareerTestRecommendation {
 
     @Id
@@ -17,10 +19,11 @@ public class CareerTestRecommendation {
 
     private int ranking;
 
+    @Column(name = "skill_id", nullable = false)
     private int skillId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "career_test_result_id")
+    @JoinColumn(name = "career_test_result_id", nullable = false)
     private CareerTestResult careerTestResult;
 
     public CareerTestRecommendation(CareerTestResult result, int skillId, int score, int ranking) {
@@ -29,4 +32,5 @@ public class CareerTestRecommendation {
         this.score = score;
         this.ranking = ranking;
     }
+
 }

--- a/src/main/java/com/_z/eum/career/entity/CareerTestResult.java
+++ b/src/main/java/com/_z/eum/career/entity/CareerTestResult.java
@@ -3,6 +3,7 @@ package com._z.eum.career.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -10,25 +11,34 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "careerTestResult")
+@NoArgsConstructor
+@Table(name = "career_test_result")
 public class CareerTestResult {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    private  Integer userId;
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
 
-    private LocalDateTime updatedAt = LocalDateTime.now();
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
     private String summary;
 
-    @OneToMany(mappedBy = "careerTestResult", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "careerTestResult", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<CareerTestRecommendation> recommendations = new ArrayList<>();
 
     public CareerTestResult(Integer userId) {
         this.userId = userId;
-        this.updatedAt = LocalDateTime.now();
     }
 
+    @PrePersist
+    @PreUpdate
+    public void updateTimestamp() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }
+
+


### PR DESCRIPTION
### 📌 PR 제목
> [Fix] 사용자 검사 이력 조회 500번대 에러 해결

---

### ✅ 작업 개요
- 사용자 검사 이력 조회 500번대 에러 해결
- 관련 이슈 번호: Closes #12 

---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| 테스트 | 스웨거 테스트 완료 |
| 기타 | 칼럼명 정확하게 매핑, 사용자 탈퇴 시 자동으로 삭제되도록 로직 변경 |

---

### 📂 관련 파일 경로
- src/main/java/com/_z/eum/career/entity/CareerTestRecommendation.java
- src/main/java/com/_z/eum/career/entity/CareerTestResult.java

---

### 🧪 테스트 및 검증
- [ ] Swagger로 직접 테스트 완료  

---

### 🙋 리뷰 포인트

---

### 📎 참고 자료
<img width="1478" height="932" alt="스크린샷 2025-08-06 오전 2 27 11" src="https://github.com/user-attachments/assets/30456210-5dc5-455e-9c5c-cc5ffff5d8a6" />

---

### 📌 기타 공유사항

