### PR TITLE
[BE] 장인 관련 API 구현

### DIFF
--- a/src/main/java/com/_z/eum/artisan/controller/ArtisanController.java
+++ b/src/main/java/com/_z/eum/artisan/controller/ArtisanController.java
@@ -1,0 +1,60 @@
+// src/main/java/com/_z/eum/artisan/controller/ArtisanController.java
+package com._z.eum.artisan.controller;
+
+import com._z.eum.artisan.dto.request.ArtisanRequest;
+import com._z.eum.artisan.dto.response.ArtisanResponse;
+import com._z.eum.artisan.service.ArtisanService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/artisans")
+public class ArtisanController {
+
+    private final ArtisanService artisanService;
+
+    // 등록
+    @PostMapping
+    @Operation(summary = "장인 회원가입", description = "이메일, 이름, 사진, 작품, 약력을 받아 회원가입 성공여부 반환")
+    public ResponseEntity<String> create(@Valid @RequestBody ArtisanRequest request){
+        artisanService.create(request);
+        return ResponseEntity.ok("회원가입 성공하였습니다.");
+    }
+
+    // 정보 수정
+    @PutMapping("/{id}")
+    @Operation(summary = "장인 정보 변경", description = "사진, 작퓸, 약력를 입력 받아 변경 정보 수정 성공 여부를 반환")
+    public ResponseEntity<String> update(@PathVariable Integer id,
+                                       @Valid @RequestBody ArtisanRequest request){
+        artisanService.update(id, request);
+        return ResponseEntity.ok("정보 변경 성공하였습니다.");
+    }
+
+    // 전체 조회
+    @GetMapping("/all")
+    @Operation(summary = "전체 장인 조회", description = "저장된 전체 장인의 정보 조회")
+    public ResponseEntity<List<ArtisanResponse>> getAll(){
+        return ResponseEntity.ok(artisanService.getAllArtisan());
+    }
+
+    // 아이디로 조회
+    @GetMapping("/{id}")
+    @Operation(summary = "아이디로 단일 장인 정보 조회", description = "장인 고유 id로 해당 장인의 정보 조회")
+    public ResponseEntity<ArtisanResponse> getOne(@PathVariable Integer id){
+        return ResponseEntity.ok(artisanService.getArtisanById(id));
+    }
+
+    // 아이디로 삭제
+    @DeleteMapping("/{id}")
+    @Operation(summary = "장인 삭제", description = "장인 삭제 기능")
+    public ResponseEntity<Void> delete(@PathVariable Integer id){
+        artisanService.deleteArtisanById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/_z/eum/artisan/dto/request/ArtisanLoginRequest.java
+++ b/src/main/java/com/_z/eum/artisan/dto/request/ArtisanLoginRequest.java
@@ -1,0 +1,4 @@
+package com._z.eum.artisan.dto.request;
+
+public class ArtisanLoginRequest {
+}

--- a/src/main/java/com/_z/eum/artisan/dto/request/ArtisanRequest.java
+++ b/src/main/java/com/_z/eum/artisan/dto/request/ArtisanRequest.java
@@ -1,0 +1,21 @@
+package com._z.eum.artisan.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ArtisanRequest(
+        @NotNull
+        int skillId,
+
+        @NotBlank
+        String name,
+
+        String email,
+
+        String photoUrl,
+
+        String mainWorks,
+        String biography
+) {
+}

--- a/src/main/java/com/_z/eum/artisan/dto/response/ArtisanResponse.java
+++ b/src/main/java/com/_z/eum/artisan/dto/response/ArtisanResponse.java
@@ -1,0 +1,12 @@
+package com._z.eum.artisan.dto.response;
+
+public record ArtisanResponse(
+        int id,
+        int skillId,
+        String name,
+        String photoUrl,
+        String mainWorks,
+        String biography,
+        String email
+) {
+}

--- a/src/main/java/com/_z/eum/artisan/entity/Artisan.java
+++ b/src/main/java/com/_z/eum/artisan/entity/Artisan.java
@@ -1,0 +1,53 @@
+// src/main/java/com/_z/eum/artisan/entity/Artisan.java
+package com._z.eum.artisan.entity;
+
+import com._z.eum.artisan.dto.request.ArtisanRequest;
+import com._z.eum.skill.entity.SkillCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "artisan")
+@Getter
+public class Artisan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+
+    @Column(name = "skill_id", nullable = false)
+    private Integer skillId;
+
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "photo_url", nullable = false, length = 1000)
+    private String photoUrl;
+
+    @Column(name = "main_works", columnDefinition = "TEXT")
+    private String mainWorks;
+
+    @Column(name = "biography", columnDefinition = "TEXT")
+    private String biography;
+
+    protected Artisan() {
+    }
+
+    public Artisan(ArtisanRequest artisanRequest) {
+        this.name = artisanRequest.name();
+        this.photoUrl = artisanRequest.photoUrl();
+        this.mainWorks = artisanRequest.mainWorks();
+        this.biography = artisanRequest.biography();
+        this.skillId = artisanRequest.skillId();
+        this.email = artisanRequest.email();
+    }
+
+    public void updateArtisanInfo(String photoUrl, String mainWorks, String biography) {
+        this.photoUrl = photoUrl;
+        this.mainWorks = mainWorks;
+        this.biography = biography;
+    }
+}

--- a/src/main/java/com/_z/eum/artisan/repository/ArtisanRepository.java
+++ b/src/main/java/com/_z/eum/artisan/repository/ArtisanRepository.java
@@ -1,0 +1,10 @@
+package com._z.eum.artisan.repository;
+
+import com._z.eum.artisan.entity.Artisan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ArtisanRepository extends JpaRepository<Artisan, Integer> {
+    Optional<Artisan> findByEmail(String email);
+}

--- a/src/main/java/com/_z/eum/artisan/service/ArtisanService.java
+++ b/src/main/java/com/_z/eum/artisan/service/ArtisanService.java
@@ -1,0 +1,81 @@
+package com._z.eum.artisan.service;
+
+
+import com._z.eum.artisan.dto.request.ArtisanRequest;
+import com._z.eum.artisan.dto.response.ArtisanResponse;
+import com._z.eum.artisan.entity.Artisan;
+import com._z.eum.artisan.repository.ArtisanRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+public class ArtisanService {
+
+    private final ArtisanRepository artisanRepository;
+
+    public ArtisanService(ArtisanRepository artisanRepository) {
+        this.artisanRepository = artisanRepository;
+    }
+
+    //등록
+    @Transactional
+    public void create(ArtisanRequest artisanRequest) {
+        if (artisanRepository.findByEmail(artisanRequest.email()).isPresent()) {
+            throw new IllegalArgumentException("이미 장인으로 등록된 이메일입니다.");
+        }
+        Artisan newArtisan = new Artisan(artisanRequest);
+
+        artisanRepository.save(newArtisan);
+    }
+
+    // 전체 장인 조회
+    public List<ArtisanResponse> getAllArtisan() {
+        return artisanRepository.findAll()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // id로 단일 장인 조회
+    public ArtisanResponse getArtisanById(Integer id) {
+        Artisan artisan = artisanRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("장인을 찾을 수 없습니다. id=" + id));
+        return toResponse(artisan);
+    }
+
+
+    // id 기준 삭제
+    @Transactional
+    public void deleteArtisanById(Integer id){
+        if (!artisanRepository.existsById(id)) {
+            throw new NoSuchElementException("장인을 찾을 수 없습니다. id=" + id);
+        }
+        artisanRepository.deleteById(id);
+    }
+
+    // 정보 수정
+    @Transactional
+    public void update(Integer id, ArtisanRequest dto){
+        Artisan artisan = artisanRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("장인을 찾을 수 없습니다. id=" + id));
+
+        artisan.updateArtisanInfo(dto.photoUrl(), dto.mainWorks(), dto.biography());
+    }
+
+    private ArtisanResponse toResponse(Artisan a) {
+        return new ArtisanResponse(
+                a.getId(),
+                a.getSkillId(),
+                a.getName(),
+                a.getPhotoUrl(),
+                a.getMainWorks(),
+                a.getBiography(),
+                a.getEmail()
+        );
+    }
+
+
+}

--- a/src/main/java/com/_z/eum/user/controller/UserController.java
+++ b/src/main/java/com/_z/eum/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
 
     // 회원 삭제
     @DeleteMapping("/{email}")
-    @Operation(summary = "[관리자] 사용자 삭제", description = "사용자 삭제 기능")
+    @Operation(summary = "사용자 삭제", description = "사용자 삭제 기능")
     public ResponseEntity<String> deleteUser(@PathVariable String email) {
         userService.deleteUserByEmail(email);
         return ResponseEntity.ok("회원 삭제 성공하였습니다.");


### PR DESCRIPTION
### 📌 PR 제목
>  장인 관련 기능 구현

---

### ✅ 작업 개요
- 장인 등록
- 정보 수정
- 삭제
- 전체 조회
- 단일 조회 
- 관련 이슈 번호: Closes #16 

---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| API 추가| 신규 API 추가 |
| DB 변경 | email 추가 |

---

### 📂 관련 파일 경로
- `src/main/java/com/project/artisan

---

### 🧪 테스트 및 검증
- [x] Postman 직접 테스트 완료  

---

### 🙋 리뷰 포인트
- 정보 수정은 사진, 작품, 약력만 가능(이름, 이메일 수정 불가)

<img width="1533" height="389" alt="스크린샷 2025-08-13 오전 5 40 06" src="https://github.com/user-attachments/assets/d357ef87-a626-4040-8d6c-d0ad586f1194" />


