### PR TITLE
[BE] 정부 헤택 API 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+.env

--- a/src/main/java/com/_z/eum/career/entity/CareerTestOption.java
+++ b/src/main/java/com/_z/eum/career/entity/CareerTestOption.java
@@ -23,3 +23,4 @@ public class CareerTestOption {
 
     protected CareerTestOption(){}
 }
+

--- a/src/main/java/com/_z/eum/governmentSupport/api/YouthPolicyApiClient.java
+++ b/src/main/java/com/_z/eum/governmentSupport/api/YouthPolicyApiClient.java
@@ -9,14 +9,20 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+
 @Component
 public class YouthPolicyApiClient {
+
     private final RestTemplate restTemplate = new RestTemplate();
-    private final String API_KEY = "973ec1bd-c85a-4f07-98f7-ad0241070426";
+
+    @Value("${YOUTH_API_KEY}")
+    private String apiKey;
 
     public List<YouthPolicyResponse> fetchYouthPolicies() {
         String url = "https://www.youthcenter.go.kr/go/ythip/getPlcy" +
-                "?apiKeyNm=" + API_KEY +
+                "?apiKeyNm=" + apiKey +
                 "&rtnType=json&pageSize=50" +
                 "&zipCd=11000";
 

--- a/src/main/java/com/_z/eum/governmentSupport/api/YouthPolicyApiClient.java
+++ b/src/main/java/com/_z/eum/governmentSupport/api/YouthPolicyApiClient.java
@@ -1,0 +1,50 @@
+package com._z.eum.governmentSupport.api;
+
+import com._z.eum.governmentSupport.dto.YouthPolicyResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+@Component
+public class YouthPolicyApiClient {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String API_KEY = "973ec1bd-c85a-4f07-98f7-ad0241070426";
+
+    public List<YouthPolicyResponse> fetchYouthPolicies() {
+        String url = "https://www.youthcenter.go.kr/go/ythip/getPlcy" +
+                "?apiKeyNm=" + API_KEY +
+                "&rtnType=json&pageSize=50" +
+                "&zipCd=11000";
+
+        try {
+            ResponseEntity<JsonNode> response = restTemplate.exchange(
+                    url, HttpMethod.GET, null, JsonNode.class
+            );
+
+            JsonNode root = response.getBody();
+            JsonNode policyList = root.path("youthPolicyList");
+
+            List<YouthPolicyResponse> result = new ArrayList<>();
+            for (JsonNode item : policyList) {
+                result.add(new YouthPolicyResponse(
+                        item.path("plcyNo").asText(),
+                        item.path("plcyNm").asText(),
+                        item.path("plcyExplnCn").asText(),
+                        item.path("lclsfNm").asText(),
+                        item.path("sprtTrgtMinAge").asText() + "~" + item.path("sprtTrgtMaxAge").asText(),
+                        item.path("zipCd").asText(),
+                        item.path("aplyUrlAddr").asText()
+                ));
+            }
+            return result;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return List.of();
+        }
+    }
+}
+

--- a/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
+++ b/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class GovernmentSupportController {
 
-
     private final GovernmentSupportService governmentSupportService;
 
     public GovernmentSupportController(GovernmentSupportService governmentSupportService){

--- a/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
+++ b/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
@@ -1,0 +1,18 @@
+package com._z.eum.governmentSupport.controller;
+
+
+import com._z.eum.governmentSupport.service.GovernmentSupportService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GovernmentSupportController {
+
+
+    private final GovernmentSupportService governmentSupportService;
+
+    public GovernmentSupportController(GovernmentSupportService governmentSupportService){
+        this.governmentSupportService = governmentSupportService;
+    }
+
+
+}

--- a/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
+++ b/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
@@ -3,6 +3,8 @@ package com._z.eum.governmentSupport.controller;
 
 import com._z.eum.governmentSupport.dto.GovernmentSupportResponse;
 import com._z.eum.governmentSupport.service.GovernmentSupportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/supports")
+@Tag(name = "정부 혜택 API", description = "일주일마다 갱신하여 지원 가능한 정부 혜택 제공")
 public class GovernmentSupportController {
 
     private final GovernmentSupportService governmentSupportService;
@@ -23,8 +26,8 @@ public class GovernmentSupportController {
 
 
     @GetMapping("/recommend/{userId}")
+    @Operation(summary = "정부혜택 조회", description = "사용자 id로 지원 가능한 정부혜택의 제목, 설명, 타겟 나이, 카테고리 제공")
     public ResponseEntity<List<GovernmentSupportResponse>> recommend(@PathVariable Integer userId) {
-        System.out.println("[컨트롤러 진입] userId: " + userId);
         List<GovernmentSupportResponse> result = governmentSupportService.recommendSupports(userId);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
+++ b/src/main/java/com/_z/eum/governmentSupport/controller/GovernmentSupportController.java
@@ -1,10 +1,18 @@
 package com._z.eum.governmentSupport.controller;
 
 
+import com._z.eum.governmentSupport.dto.GovernmentSupportResponse;
 import com._z.eum.governmentSupport.service.GovernmentSupportService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
+@RequestMapping("/api/supports")
 public class GovernmentSupportController {
 
     private final GovernmentSupportService governmentSupportService;
@@ -14,4 +22,10 @@ public class GovernmentSupportController {
     }
 
 
+    @GetMapping("/recommend/{userId}")
+    public ResponseEntity<List<GovernmentSupportResponse>> recommend(@PathVariable Integer userId) {
+        System.out.println("[컨트롤러 진입] userId: " + userId);
+        List<GovernmentSupportResponse> result = governmentSupportService.recommendSupports(userId);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/com/_z/eum/governmentSupport/dto/GovernmentSupportResponse.java
+++ b/src/main/java/com/_z/eum/governmentSupport/dto/GovernmentSupportResponse.java
@@ -1,0 +1,17 @@
+package com._z.eum.governmentSupport.dto;
+
+import com._z.eum.governmentSupport.entity.GovernmentSupport;
+
+public record GovernmentSupportResponse(
+        String title,
+        String description,
+        String category,
+        String targetAge,
+        String targetLocation,
+        String url
+) {
+    public GovernmentSupportResponse(GovernmentSupport s) {
+        this(s.getTitle(), s.getDescription(), s.getCategory(),
+                s.getTargetAge(), s.getTargetLocation(), s.getUrl());
+    }
+}

--- a/src/main/java/com/_z/eum/governmentSupport/dto/GovernmentSupportResponse.java
+++ b/src/main/java/com/_z/eum/governmentSupport/dto/GovernmentSupportResponse.java
@@ -7,11 +7,10 @@ public record GovernmentSupportResponse(
         String description,
         String category,
         String targetAge,
-        String targetLocation,
         String url
 ) {
     public GovernmentSupportResponse(GovernmentSupport s) {
         this(s.getTitle(), s.getDescription(), s.getCategory(),
-                s.getTargetAge(), s.getTargetLocation(), s.getUrl());
+                s.getTargetAge(), s.getUrl());
     }
 }

--- a/src/main/java/com/_z/eum/governmentSupport/dto/YouthPolicyResponse.java
+++ b/src/main/java/com/_z/eum/governmentSupport/dto/YouthPolicyResponse.java
@@ -1,0 +1,12 @@
+package com._z.eum.governmentSupport.dto;
+
+public record YouthPolicyResponse(
+        String sourceApi,
+        String title,
+        String description,
+        String category,
+        String targetAge,
+        String targetLocation,
+        String url
+) {
+}

--- a/src/main/java/com/_z/eum/governmentSupport/entity/GovernmentSupport.java
+++ b/src/main/java/com/_z/eum/governmentSupport/entity/GovernmentSupport.java
@@ -1,0 +1,32 @@
+package com._z.eum.governmentSupport.entity;
+
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class GovernmentSupport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private String category;
+
+    private String targetAge;
+
+    private String targetLocation;
+
+    @Column(columnDefinition = "TEXT")
+    private String url;
+
+    private String sourceApi;
+
+
+}

--- a/src/main/java/com/_z/eum/governmentSupport/entity/GovernmentSupport.java
+++ b/src/main/java/com/_z/eum/governmentSupport/entity/GovernmentSupport.java
@@ -2,15 +2,19 @@ package com._z.eum.governmentSupport.entity;
 
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Table(name = "government_support")
 public class GovernmentSupport {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Integer id;
 
     private String title;
 
@@ -28,5 +32,28 @@ public class GovernmentSupport {
 
     private String sourceApi;
 
+    protected GovernmentSupport(){}
 
+
+    public GovernmentSupport(String title, String description, String category,
+                             String targetAge, String targetLocation, String url, String sourceApi) {
+        this.title = title;
+        this.description = description;
+        this.category = category;
+        this.targetAge = targetAge;
+        this.targetLocation = targetLocation;
+        this.url = url;
+        this.sourceApi = sourceApi;
+    }
+
+    // 필요한 경우 setter 대신 update 메서드로 수정할 수 있음
+    public void update(String title, String description, String category,
+                       String targetAge, String targetLocation, String url) {
+        this.title = title;
+        this.description = description;
+        this.category = category;
+        this.targetAge = targetAge;
+        this.targetLocation = targetLocation;
+        this.url = url;
+    }
 }

--- a/src/main/java/com/_z/eum/governmentSupport/entity/UserSupportResult.java
+++ b/src/main/java/com/_z/eum/governmentSupport/entity/UserSupportResult.java
@@ -2,7 +2,6 @@ package com._z.eum.governmentSupport.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/_z/eum/governmentSupport/entity/UserSupportResult.java
+++ b/src/main/java/com/_z/eum/governmentSupport/entity/UserSupportResult.java
@@ -2,11 +2,13 @@ package com._z.eum.governmentSupport.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Table(name = "userSupport_result")
 public class UserSupportResult {
 
     @Id
@@ -14,7 +16,7 @@ public class UserSupportResult {
     private Integer id;
 
     @Column(nullable = false)
-    private Long userId;
+    private Integer userId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "support_id", nullable = false)
@@ -26,5 +28,14 @@ public class UserSupportResult {
     @Column(nullable = false)
     private boolean isRead = false;
 
+    protected UserSupportResult(){}
+
+
+    public UserSupportResult(Integer userId, GovernmentSupport support, LocalDateTime recommendedAt, boolean isRead) {
+        this.userId = userId;
+        this.support = support;
+        this.recommendedAt = recommendedAt;
+        this.isRead = isRead;
+    }
 
 }

--- a/src/main/java/com/_z/eum/governmentSupport/entity/UserSupportResult.java
+++ b/src/main/java/com/_z/eum/governmentSupport/entity/UserSupportResult.java
@@ -1,0 +1,30 @@
+package com._z.eum.governmentSupport.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class UserSupportResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "support_id", nullable = false)
+    private GovernmentSupport support;
+
+    @Column(nullable = false)
+    private LocalDateTime recommendedAt;
+
+    @Column(nullable = false)
+    private boolean isRead = false;
+
+
+}

--- a/src/main/java/com/_z/eum/governmentSupport/repository/GovernmentSupportRepository.java
+++ b/src/main/java/com/_z/eum/governmentSupport/repository/GovernmentSupportRepository.java
@@ -1,0 +1,11 @@
+package com._z.eum.governmentSupport.repository;
+
+import com._z.eum.governmentSupport.entity.GovernmentSupport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GovernmentSupportRepository extends JpaRepository<GovernmentSupport, Integer> {
+
+    Optional<GovernmentSupport> findBySourceApi(String sourceApi);
+}

--- a/src/main/java/com/_z/eum/governmentSupport/repository/SupportRepository.java
+++ b/src/main/java/com/_z/eum/governmentSupport/repository/SupportRepository.java
@@ -1,0 +1,4 @@
+package com._z.eum.governmentSupport.repository;
+
+public class SupportRepository {
+}

--- a/src/main/java/com/_z/eum/governmentSupport/repository/SupportRepository.java
+++ b/src/main/java/com/_z/eum/governmentSupport/repository/SupportRepository.java
@@ -1,4 +1,0 @@
-package com._z.eum.governmentSupport.repository;
-
-public class SupportRepository {
-}

--- a/src/main/java/com/_z/eum/governmentSupport/repository/UserSupportResultRepository.java
+++ b/src/main/java/com/_z/eum/governmentSupport/repository/UserSupportResultRepository.java
@@ -1,0 +1,14 @@
+package com._z.eum.governmentSupport.repository;
+
+import com._z.eum.governmentSupport.entity.UserSupportResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserSupportResultRepository extends JpaRepository<UserSupportResult, Integer> {
+
+    List<UserSupportResult> findByUserId(Integer userId);
+
+    Optional<UserSupportResult> findTopByUserIdOrderByRecommendedAtDesc(Integer userId);
+}

--- a/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
+++ b/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
@@ -52,9 +52,7 @@ public class GovernmentSupportService {
             System.out.println("[정책 수신] 수신된 정책 개수: " + fetched.size());
             saveOrUpdateGovernmentSupport(fetched);
 
-            // 필터 조건 완화 또는 제거: 주소 문자열은 법정동코드와 다를 수 있으므로 정책 매칭 안될 수 있음
             List<GovernmentSupport> filtered = govRepo.findAll().stream()
-                    // .filter(s -> location == null || s.getTargetLocation() == null || location.contains(s.getTargetLocation()))
                     .filter(s -> ageMatches(age, s.getTargetAge()))
                     .toList();
             System.out.println("[정책 필터링] 추천 대상 정책 개수: " + filtered.size());

--- a/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
+++ b/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
@@ -1,0 +1,19 @@
+package com._z.eum.governmentSupport.service;
+
+
+import com._z.eum.governmentSupport.repository.SupportRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GovernmentSupportService {
+
+    private final SupportRepository supportRepository;
+
+    public GovernmentSupportService(SupportRepository supportRepository){
+        this.supportRepository = supportRepository;
+    }
+
+
+
+
+}

--- a/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
+++ b/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
@@ -1,16 +1,16 @@
 package com._z.eum.governmentSupport.service;
 
 
-import com._z.eum.governmentSupport.repository.SupportRepository;
+import com._z.eum.governmentSupport.repository.GovernmentSupportRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 public class GovernmentSupportService {
 
-    private final SupportRepository supportRepository;
+    private final GovernmentSupportRepository governmentSupportRepository;
 
-    public GovernmentSupportService(SupportRepository supportRepository){
-        this.supportRepository = supportRepository;
+    public GovernmentSupportService(GovernmentSupportRepository governmentSupportRepository){
+        this.governmentSupportRepository = governmentSupportRepository;
     }
 
 

--- a/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
+++ b/src/main/java/com/_z/eum/governmentSupport/service/GovernmentSupportService.java
@@ -1,19 +1,121 @@
 package com._z.eum.governmentSupport.service;
 
 
+import com._z.eum.governmentSupport.api.YouthPolicyApiClient;
+import com._z.eum.governmentSupport.dto.GovernmentSupportResponse;
+import com._z.eum.governmentSupport.dto.YouthPolicyResponse;
+import com._z.eum.governmentSupport.entity.GovernmentSupport;
+import com._z.eum.governmentSupport.entity.UserSupportResult;
 import com._z.eum.governmentSupport.repository.GovernmentSupportRepository;
+import com._z.eum.governmentSupport.repository.UserSupportResultRepository;
+import com._z.eum.user.entity.User;
+import com._z.eum.user.service.UserService;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class GovernmentSupportService {
 
-    private final GovernmentSupportRepository governmentSupportRepository;
+    private final GovernmentSupportRepository govRepo;
+    private final UserSupportResultRepository userSupportRepo;
+    private final YouthPolicyApiClient apiClient;
+    private final UserService userService;
 
-    public GovernmentSupportService(GovernmentSupportRepository governmentSupportRepository){
-        this.governmentSupportRepository = governmentSupportRepository;
+    public GovernmentSupportService(GovernmentSupportRepository govRepo,
+                                    UserSupportResultRepository userSupportRepo,
+                                    YouthPolicyApiClient apiClient,
+                                    UserService userService
+                                    ) {
+        this.govRepo = govRepo;
+        this.userSupportRepo = userSupportRepo;
+        this.apiClient = apiClient;
+        this.userService = userService;
+    }
+    public List<GovernmentSupportResponse> recommendSupports(Integer userId) {
+        System.out.println("[추천 시작] userId: " + userId);
+        User user = userService.getUserById(userId);
+        System.out.println("[유저 정보] 나이: " + user.getAge() + ", 주소: " + user.getAddress());
+        int age = user.getAge();
+        String location = user.getAddress();
+
+        Optional<UserSupportResult> recent = userSupportRepo.findTopByUserIdOrderByRecommendedAtDesc(userId);
+
+        System.out.println("[추천 이력] 최근 이력 존재 여부: " + recent.isPresent());
+        boolean needUpdate = recent.isEmpty() ||
+                recent.get().getRecommendedAt().isBefore(LocalDateTime.now().minusDays(7));
+
+        if (needUpdate) {
+            List<YouthPolicyResponse> fetched = apiClient.fetchYouthPolicies();
+            System.out.println("[정책 수신] 수신된 정책 개수: " + fetched.size());
+            saveOrUpdateGovernmentSupport(fetched);
+
+            // 필터 조건 완화 또는 제거: 주소 문자열은 법정동코드와 다를 수 있으므로 정책 매칭 안될 수 있음
+            List<GovernmentSupport> filtered = govRepo.findAll().stream()
+                    // .filter(s -> location == null || s.getTargetLocation() == null || location.contains(s.getTargetLocation()))
+                    .filter(s -> ageMatches(age, s.getTargetAge()))
+                    .toList();
+            System.out.println("[정책 필터링] 추천 대상 정책 개수: " + filtered.size());
+            for (GovernmentSupport support : filtered) {
+                UserSupportResult result = new UserSupportResult(
+                        userId,
+                        support,
+                        LocalDateTime.now(),
+                        false
+                );
+                userSupportRepo.save(result);
+            }
+
+        }
+
+        return userSupportRepo.findByUserId(userId).stream()
+                .map(r -> new GovernmentSupportResponse(r.getSupport()))
+                .toList();
+    }
+
+    private void saveOrUpdateGovernmentSupport(List<YouthPolicyResponse> dtos) {
+        for (YouthPolicyResponse dto : dtos) {
+            govRepo.findBySourceApi(dto.sourceApi()).ifPresentOrElse(
+                    existing -> existing.update(
+                            dto.title(),
+                            dto.description(),
+                            dto.category(),
+                            dto.targetAge(),
+                            dto.targetLocation(),
+                            dto.url()
+                    ),
+                    () -> {
+                        GovernmentSupport newSupport = new GovernmentSupport(
+                                dto.title(),
+                                dto.description(),
+                                dto.category(),
+                                dto.targetAge(),
+                                dto.targetLocation(),
+                                dto.url(),
+                                dto.sourceApi()
+                        );
+                        govRepo.save(newSupport);
+                    }
+            );
+        }
     }
 
 
-
-
+    private boolean ageMatches(int userAge, String targetAge) {
+        if (targetAge == null || targetAge.isBlank()) return true;
+        try {
+            if (targetAge.contains("~")) {
+                String[] parts = targetAge.replaceAll("[^0-9~]", "").split("~");
+                int min = Integer.parseInt(parts[0]);
+                int max = Integer.parseInt(parts[1]);
+                return userAge >= min && userAge <= max;
+            } else if (targetAge.contains("이상")) {
+                int min = Integer.parseInt(targetAge.replaceAll("[^0-9]", ""));
+                return userAge >= min;
+            }
+        } catch (Exception ignored) {}
+        return true;
+    }
 }

--- a/src/main/java/com/_z/eum/user/service/UserService.java
+++ b/src/main/java/com/_z/eum/user/service/UserService.java
@@ -75,4 +75,9 @@ public class UserService {
         userRepository.delete(user);
     }
 
+    public User getUserById(Integer userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 아이디의 회원이 존재하지 않습니다."));
+
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ server:
   address : 0.0.0.0
 
 spring:
+  config:
+    import: optional:file:.env
+
   datasource:
     url: jdbc:mysql://localhost:3306/eum?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
### 📌 PR 제목
> [BE] 정부 헤택 API 구현 

---

### ✅ 작업 개요
- 온통청년 api를 이용하여 서울특별시의 정부 혜택 정보를 제공함 (20개)
- [1] 사용자가 추천 요청 (userId, 나이, 지역 등 전달)
- [2] UserSupportResult에서 userId에 대한 추천 기록이 있는지 확인
- [2-1] 추천 이력이 없거나 recommended_at이 7일 이상 지남→ 외부 API 호출 → GovernmentSupport 갱신→ 정책 필터링 → UserSupportResult 새로 저장
- [2-2] 추천 이력이 있고, 7일 이내면→ UserSupportResult에 있는 추천 정책 그대로 반환

- 관련 이슈 번호: Closes #14 
---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| API 추가/변경 | 신규 API 추가 |

---

### 📂 관련 파일 경로
- `src/main/java/com/project/support`  

---

### 🧪 테스트 및 검증
- [ ] Postman  테스트 완료  

---

### 🙋 리뷰 포인트
- 로직 복잡한 부분이나 리뷰어가 중점적으로 확인해야 할 부분 설명

---

### 📎 참고 자료
- API 명세 문서, ERD, 회의록 등

---

### 📌 기타 공유사항
- 추가적인 논의가 필요한 사항 또는 특별한 상황

