### PR TITLE
[BE]  매칭 요청 쪽지 기능 구현

### DIFF
--- a/src/main/java/com/_z/eum/matching/controller/MatchingRequestController.java
+++ b/src/main/java/com/_z/eum/matching/controller/MatchingRequestController.java
@@ -38,6 +38,15 @@ public class MatchingRequestController {
         return ResponseEntity.ok(service.listForArtisan(artisanId, unreadOnly));
     }
 
+    @GetMapping("/user/{userId}")
+    @Operation(summary = "사용자 본인이 보낸 쪽지 목록", description = "사용자가 자신이 보낸 모든 쪽지를 확인")
+    public ResponseEntity<List<ArtisanMessageResponse>> listForUser(
+            @PathVariable Integer userId
+    ) {
+        return ResponseEntity.ok(service.listForUser(userId));
+    }
+
+
     // 읽음 처리
     @PatchMapping("/artisan/{artisanId}/{messageId}/read")
     @Operation(summary = "쪽지 읽음 처리", description = "장인이 자신의 쪽지를 읽음 처리")

--- a/src/main/java/com/_z/eum/matching/controller/MatchingRequestController.java
+++ b/src/main/java/com/_z/eum/matching/controller/MatchingRequestController.java
@@ -1,0 +1,51 @@
+
+package com._z.eum.matching.controller;
+
+import com._z.eum.matching.dto.ArtisanMessageResponse;
+import com._z.eum.matching.dto.MatchingCreateRequest;
+import com._z.eum.matching.service.MatchingRequestService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/matching-requests")
+public class MatchingRequestController {
+
+    private final MatchingRequestService service;
+
+    //쪽지 보내기
+    @PostMapping
+    @Operation(summary = "장인에게 쪽지 보내기", description = "사용자 -> 장인 : 익명 여부에 따라 사용자 정보 노출 제어")
+    public ResponseEntity<Void> create(@Validated @RequestBody MatchingCreateRequest req) {
+        Integer id = service.create(req);
+        return ResponseEntity.created(URI.create("/api/matching-requests/" + id)).build();
+    }
+
+   //쪽지 조회
+    @GetMapping("/artisan/{artisanId}")
+    @Operation(summary = "장인 받은 쪽지 목록", description = "익명 여부, 메시지, 작성일, 읽음 여부를 조회. 익명 아니면 사용자 이름/이메일/나이 포함")
+    public ResponseEntity<List<ArtisanMessageResponse>> list(
+            @PathVariable Integer artisanId,
+            @RequestParam(defaultValue = "false") boolean unreadOnly
+    ) {
+        return ResponseEntity.ok(service.listForArtisan(artisanId, unreadOnly));
+    }
+
+    // 읽음 처리
+    @PatchMapping("/artisan/{artisanId}/{messageId}/read")
+    @Operation(summary = "쪽지 읽음 처리", description = "장인이 자신의 쪽지를 읽음 처리")
+    public ResponseEntity<Void> markRead(
+            @PathVariable Integer artisanId,
+            @PathVariable Integer messageId
+    ) {
+        service.markRead(artisanId, messageId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/_z/eum/matching/dto/ArtisanMessageResponse.java
+++ b/src/main/java/com/_z/eum/matching/dto/ArtisanMessageResponse.java
@@ -1,0 +1,25 @@
+
+package com._z.eum.matching.dto;
+
+import java.time.LocalDateTime;
+
+public record ArtisanMessageResponse(
+        Integer id,
+
+        Boolean isAnonymous,
+
+        String message,
+
+        LocalDateTime requestDate,
+
+        Boolean isRead,
+
+        LocalDateTime readAt,
+
+        // 익명이 아닐 때만 채워짐
+        String senderName,
+
+        String senderEmail,
+
+        Integer senderAge
+) {}

--- a/src/main/java/com/_z/eum/matching/dto/ArtisanMessageResponse.java
+++ b/src/main/java/com/_z/eum/matching/dto/ArtisanMessageResponse.java
@@ -1,25 +1,35 @@
-
 package com._z.eum.matching.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "장인 또는 사용자가 조회할 때 반환되는 쪽지 응답 DTO")
 public record ArtisanMessageResponse(
+
+        @Schema(description = "쪽지 ID", example = "5")
         Integer id,
 
+        @Schema(description = "익명 여부", example = "false")
         Boolean isAnonymous,
 
+        @Schema(description = "쪽지 본문", example = "안녕하세요, 작품 관련 상담을 원합니다.")
         String message,
 
+        @Schema(description = "작성 시간", example = "2025-08-17T01:30:00")
         LocalDateTime requestDate,
 
-        Boolean isRead,
+        @Schema(description = "읽음 여부", example = "true")
+        Boolean read,
 
+        @Schema(description = "읽은 시간", example = "2025-08-17T02:00:00")
         LocalDateTime readAt,
 
-        // 익명이 아닐 때만 채워짐
+        @Schema(description = "보낸 사용자 이름 (익명이면 null)", example = "김보빈")
         String senderName,
 
+        @Schema(description = "보낸 사용자 이메일 (익명이면 null)", example = "bobin@example.com")
         String senderEmail,
 
+        @Schema(description = "보낸 사용자 나이 (익명이면 null)", example = "25")
         Integer senderAge
 ) {}

--- a/src/main/java/com/_z/eum/matching/dto/MatchingCreateRequest.java
+++ b/src/main/java/com/_z/eum/matching/dto/MatchingCreateRequest.java
@@ -1,0 +1,18 @@
+
+package com._z.eum.matching.dto;
+
+import jakarta.validation.constraints.*;
+
+public record MatchingCreateRequest(
+        @NotNull
+        Integer userId,
+
+        @NotNull
+        Integer artisanId,
+
+        @NotBlank @Size(max = 250)
+        String message,
+
+        @NotNull
+        Boolean isAnonymous
+) {}

--- a/src/main/java/com/_z/eum/matching/dto/MatchingCreateRequest.java
+++ b/src/main/java/com/_z/eum/matching/dto/MatchingCreateRequest.java
@@ -1,18 +1,19 @@
-
 package com._z.eum.matching.dto;
 
-import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "사용자가 장인에게 보내는 쪽지 요청 DTO")
 public record MatchingCreateRequest(
-        @NotNull
+
+        @Schema(description = "사용자 ID", example = "1")
         Integer userId,
 
-        @NotNull
+        @Schema(description = "장인 ID", example = "10")
         Integer artisanId,
 
-        @NotBlank @Size(max = 250)
+        @Schema(description = "쪽지 본문 (최대 250자)", example = "안녕하세요, 작품 관련 상담을 원합니다.")
         String message,
 
-        @NotNull
+        @Schema(description = "익명 여부", example = "false")
         Boolean isAnonymous
 ) {}

--- a/src/main/java/com/_z/eum/matching/entity/MatchingRequest.java
+++ b/src/main/java/com/_z/eum/matching/entity/MatchingRequest.java
@@ -1,0 +1,63 @@
+// src/main/java/com/_z/eum/matching/entity/MatchingRequest.java
+package com._z.eum.matching.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "matching_request")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED) // JPA 기본 생성자
+public class MatchingRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "artisan_id", nullable = false)
+    private Integer artisanId;
+
+    @Lob
+    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
+    @Size(max = 250)
+    private String message;
+
+    @Column(name = "is_anonymous", nullable = false)
+    private boolean anonymous;
+
+    @Column(name = "request_date", nullable = false)
+    private LocalDateTime requestDate;
+
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+
+    public MatchingRequest(Integer userId, Integer artisanId, String message, boolean anonymous) {
+        this.userId = userId;
+        this.artisanId = artisanId;
+        this.message = message;
+        this.anonymous = anonymous;
+        this.requestDate = LocalDateTime.now();
+        this.read = false;
+        this.readAt = null;
+    }
+
+    public void markRead() {
+        if (!this.read) {
+            this.read = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/_z/eum/matching/entity/Notification.java
+++ b/src/main/java/com/_z/eum/matching/entity/Notification.java
@@ -1,0 +1,63 @@
+
+package com._z.eum.matching.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "artisan_id", nullable = false)
+    private Integer artisanId;
+
+    @Column(name = "matching_request_id", nullable = false)
+    private Integer matchingRequestId;
+
+    @Column(name = "type", nullable = false, length = 50)
+    private String type;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "body", length = 500)
+    private String body;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+
+    public Notification(Integer artisanId, Integer matchingRequestId, String type, String title, String body) {
+        this.artisanId = artisanId;
+        this.matchingRequestId = matchingRequestId;
+        this.type = type;
+        this.title = title;
+        this.body = body;
+        this.read = false;
+        this.createdAt = LocalDateTime.now();
+        this.readAt = null;
+    }
+
+    public void markRead() {
+        if (!this.read) {
+            this.read = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
+
+}

--- a/src/main/java/com/_z/eum/matching/repository/MatchingRequestRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/MatchingRequestRepository.java
@@ -1,0 +1,14 @@
+
+package com._z.eum.matching.repository;
+
+import com._z.eum.matching.entity.MatchingRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MatchingRequestRepository extends JpaRepository<MatchingRequest, Integer> {
+
+    List<MatchingRequest> findByArtisanIdOrderByRequestDateDesc(Integer artisanId);
+
+    List<MatchingRequest> findByArtisanIdAndReadFalseOrderByRequestDateDesc(Integer artisanId);
+}

--- a/src/main/java/com/_z/eum/matching/repository/MatchingRequestRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/MatchingRequestRepository.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public interface MatchingRequestRepository extends JpaRepository<MatchingRequest, Integer> {
 
+    List<MatchingRequest> findByUserIdOrderByRequestDateDesc(Integer userId);
+
     List<MatchingRequest> findByArtisanIdOrderByRequestDateDesc(Integer artisanId);
 
     List<MatchingRequest> findByArtisanIdAndReadFalseOrderByRequestDateDesc(Integer artisanId);

--- a/src/main/java/com/_z/eum/matching/repository/NotificationRepository.java
+++ b/src/main/java/com/_z/eum/matching/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+
+package com._z.eum.matching.repository;
+
+import com._z.eum.matching.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Integer> {
+
+    List<Notification> findByArtisanIdAndReadFalseOrderByCreatedAtDesc(Integer artisanId);
+}

--- a/src/main/java/com/_z/eum/matching/service/MatchingRequestService.java
+++ b/src/main/java/com/_z/eum/matching/service/MatchingRequestService.java
@@ -105,6 +105,22 @@ public class MatchingRequestService {
         }).toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<ArtisanMessageResponse> listForUser(Integer userId) {
+        List<MatchingRequest> list = matchingRepo.findByUserIdOrderByRequestDateDesc(userId);
+
+        return list.stream().map(mr -> new ArtisanMessageResponse(
+                mr.getId(),
+                mr.isAnonymous(),
+                mr.getMessage(),
+                mr.getRequestDate(),
+                mr.isRead(),
+                mr.getReadAt(),
+                null, null, null // 사용자 본인이 보는 거라 sender 정보 필요 없음
+        )).toList();
+    }
+
+
     @Transactional
     public void markRead(Integer artisanId, Integer messageId) {
         com._z.eum.matching.entity.MatchingRequest mr = matchingRepo.findById(messageId)

--- a/src/main/java/com/_z/eum/matching/service/MatchingRequestService.java
+++ b/src/main/java/com/_z/eum/matching/service/MatchingRequestService.java
@@ -1,0 +1,126 @@
+
+package com._z.eum.matching.service;
+
+import com._z.eum.artisan.entity.Artisan;
+import com._z.eum.artisan.repository.ArtisanRepository;
+import com._z.eum.matching.dto.ArtisanMessageResponse;
+import com._z.eum.matching.dto.MatchingCreateRequest;
+import com._z.eum.matching.entity.MatchingRequest;
+import com._z.eum.matching.entity.Notification;
+import com._z.eum.matching.repository.MatchingRequestRepository;
+import com._z.eum.matching.repository.NotificationRepository;
+import com._z.eum.user.entity.User;
+import com._z.eum.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class MatchingRequestService {
+
+    private final MatchingRequestRepository matchingRepo;
+    private final NotificationRepository notifRepo;
+    private final UserRepository userRepo;
+    private final ArtisanRepository artisanRepo;
+
+
+    public MatchingRequestService( MatchingRequestRepository matchingRepo,
+                                   NotificationRepository notifRepo,
+                                   UserRepository userRepo,
+                                   ArtisanRepository artisanRepo) {
+        this.artisanRepo = artisanRepo;
+        this.matchingRepo = matchingRepo;
+        this.notifRepo = notifRepo;
+        this.userRepo = userRepo;
+    }
+
+
+
+    @Transactional
+    public Integer create(MatchingCreateRequest dto) {
+
+        // 존재 검증
+        User user = userRepo.findById(dto.userId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 사용자 없음"));
+
+        Artisan artisan = artisanRepo.findById(dto.artisanId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 장인 없음"));
+
+
+
+       MatchingRequest mr =
+                new com._z.eum.matching.entity.MatchingRequest(
+                        user.getId(),
+                        artisan.getId(),
+                        dto.message(),
+                        dto.isAnonymous()
+                );
+
+        matchingRepo.save(mr);
+
+
+        String title = "새로운 매칭 요청";
+        String body  = "새로운 사용자로부터 매칭 요청이 도착했습니다.";
+        Notification noti = new Notification(
+                artisan.getId(),
+                mr.getId(),
+                "NEW_MESSAGE",
+                title,
+                body
+        );
+        notifRepo.save(noti);
+
+        //푸시 알림
+
+        return mr.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ArtisanMessageResponse> listForArtisan(Integer artisanId, boolean unreadOnly) {
+        List<com._z.eum.matching.entity.MatchingRequest> list = unreadOnly
+                ? matchingRepo.findByArtisanIdAndReadFalseOrderByRequestDateDesc(artisanId)
+                : matchingRepo.findByArtisanIdOrderByRequestDateDesc(artisanId);
+
+        return list.stream().map(mr -> {
+            String name = null, email = null;
+            Integer age = null;
+            if (!mr.isAnonymous()) {
+                User u = userRepo.findById(mr.getUserId()).orElse(null);
+                if (u != null) {
+                    name = u.getName();
+                    email = u.getEmail();
+                    age = u.getAge();
+                }
+            }
+            return new ArtisanMessageResponse(
+                    mr.getId(),
+                    mr.isAnonymous(),
+                    mr.getMessage(),
+                    mr.getRequestDate(),
+                    mr.isRead(),
+                    mr.getReadAt(),
+                    name, email, age
+            );
+        }).toList();
+    }
+
+    @Transactional
+    public void markRead(Integer artisanId, Integer messageId) {
+        com._z.eum.matching.entity.MatchingRequest mr = matchingRepo.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("쪽지 없음"));
+
+        if (!mr.getArtisanId().equals(artisanId)) {
+            throw new IllegalArgumentException("권한 없음");
+        }
+
+
+        mr.markRead();
+
+        // 관련 알림 읽음 처리
+        notifRepo.findByArtisanIdAndReadFalseOrderByCreatedAtDesc(artisanId).stream()
+                .filter(n -> n.getMatchingRequestId().equals(messageId))
+                .findFirst()
+                .ifPresent(Notification::markRead);
+    }
+}


### PR DESCRIPTION
### 📌 PR 제목
> [BE]  매칭 요청 쪽지 기능 구현
---

### ✅ 작업 개요
- 관련 이슈 번호: Closes #20 
- 사용자 → 장인 단방향 쪽지(매칭요청) 기능 구현
- 매칭요청 발생 시 알림(Notification) 자동 생성
- 장인/사용자 모두 자신의 쪽지 목록 확인 가능
- 쪽지 읽음 처리 및 알림 상태 동기화 지원
- Swagger 예시 추가로 API 문서 품질 개선
- 읽음 처리 로직

---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| API 추가/변경 | 신규 API 추가 |
| 로직 수정 | 매칭 요청 + 알림 기능 한 번에 구현  |
| 테스트 | 스웨거 테스트용 스키마 추가  |

---

### 📂 관련 파일 경로
- `src/main/java/com/project/matching`  

---

### 🧪 테스트 및 검증
- [ ] Postman  직접 테스트 완료  

---


### 📌 기타 공유사항
- 푸시 알림 기능 추가 예정 (구글 외부 api 이용 )

