### PR TITLE
[BE] 원데이 클래스 관련 API 구현 

### DIFF
--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/controller/ClassScheduleController.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/controller/ClassScheduleController.java
@@ -1,0 +1,69 @@
+package com._z.eum.onedayClass.classSchedules.controller;
+
+import com._z.eum.onedayClass.classSchedules.dto.request.ClassScheduleRequest;
+import com._z.eum.onedayClass.classSchedules.dto.response.ClassScheduleResponse;
+import com._z.eum.onedayClass.classSchedules.service.ClassScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/class-schedules")
+@Tag(name = "클래스 일정 API", description = "클래스 일정 등록, 조회, 수정, 삭제 기능 제공")
+public class ClassScheduleController {
+
+    private final ClassScheduleService classScheduleService;
+
+    public ClassScheduleController(ClassScheduleService classScheduleService) {
+        this.classScheduleService = classScheduleService;
+    }
+
+    // 전체 일정 조회
+    @GetMapping("/all")
+    @Operation(summary = "전체 일정 조회", description = "저장된 모든 클래스 일정 조회")
+    public ResponseEntity<List<ClassScheduleResponse>> getAllSchedules() {
+        return ResponseEntity.ok(classScheduleService.getAllSchedules());
+    }
+
+    // 특정 클래스 일정 전체 조회
+    @GetMapping("/class/{classId}")
+    @Operation(summary = "특정 클래스 일정 조회", description = "클래스 ID로 해당 클래스의 모든 일정 조회")
+    public ResponseEntity<List<ClassScheduleResponse>> getSchedulesByClass(@PathVariable int classId) {
+        return ResponseEntity.ok(classScheduleService.getSchedulesByClass(classId));
+    }
+
+    // 단일 일정 조회
+    @GetMapping("/{id}")
+    @Operation(summary = "일정 단일 조회", description = "일정 ID로 특정 클래스 일정 조회")
+    public ResponseEntity<ClassScheduleResponse> getSchedule(@PathVariable int id) {
+        return ResponseEntity.ok(classScheduleService.getSchedule(id));
+    }
+
+    // 일정 생성
+    @PostMapping
+    @Operation(summary = "일정 등록", description = "새로운 클래스를 일정으로 등록")
+    public ResponseEntity<ClassScheduleResponse> createSchedule(@RequestBody ClassScheduleRequest request) {
+        return ResponseEntity.ok(classScheduleService.createSchedule(request));
+    }
+
+    // 일정 수정
+    @PutMapping("/{id}")
+    @Operation(summary = "일정 수정", description = "일정 ID를 기준으로 일정 정보 수정")
+    public ResponseEntity<ClassScheduleResponse> updateSchedule(
+            @PathVariable int id,
+            @RequestBody ClassScheduleRequest request
+    ) {
+        return ResponseEntity.ok(classScheduleService.updateSchedule(id, request));
+    }
+
+    // 일정 삭제
+    @DeleteMapping("/{id}")
+    @Operation(summary = "일정 삭제", description = "일정 ID를 기준으로 일정 삭제")
+    public ResponseEntity<String> deleteSchedule(@PathVariable int id) {
+        classScheduleService.deleteSchedule(id);
+        return ResponseEntity.ok("일정 삭제 성공했습니다.");
+    }
+}

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/dto/request/ClassScheduleRequest.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/dto/request/ClassScheduleRequest.java
@@ -1,0 +1,25 @@
+package com._z.eum.onedayClass.classSchedules.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "클래스 일정 생성/수정 요청 DTO")
+public record ClassScheduleRequest(
+
+        @Schema(description = "클래스 ID", example = "1")
+        int classId,
+
+        @Schema(description = "수업 날짜 (년월일)", example = "2025-10-02")
+        LocalDate date,
+
+        @Schema(description = "수업 시간 (시:분)", example = "14:00:00")
+        LocalTime timeSlot,
+
+        @Schema(description = "최대 수용 인원", example = "12")
+        int capacity,
+
+        @Schema(description = "현재 예약된 인원", example = "0")
+        int currentCount
+) {}

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/dto/response/ClassScheduleResponse.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/dto/response/ClassScheduleResponse.java
@@ -1,0 +1,28 @@
+package com._z.eum.onedayClass.classSchedules.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "클래스 일정 응답 DTO")
+public record ClassScheduleResponse(
+
+        @Schema(description = "일정 ID", example = "10")
+        int id,
+
+        @Schema(description = "클래스 ID", example = "1")
+        int classId,
+
+        @Schema(description = "수업 날짜 (년월일)", example = "2025-10-02")
+        LocalDate date,
+
+        @Schema(description = "수업 시간 (시:분)", example = "14:00:00")
+        LocalTime timeSlot,
+
+        @Schema(description = "최대 수용 인원", example = "12")
+        int capacity,
+
+        @Schema(description = "현재 예약된 인원", example = "5")
+        int currentCount
+) {}

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/entity/ClassSchedule.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/entity/ClassSchedule.java
@@ -1,0 +1,38 @@
+package com._z.eum.onedayClass.classSchedules.entity;
+
+import com._z.eum.onedayClass.classes.entity.Classes;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "class_schedule")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClassSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id", nullable = false)
+    private Classes classes;
+
+    // 수업 날짜 (년월일)
+    private LocalDate date;
+
+    // 수업 시간 (시분)
+    private LocalTime timeSlot;
+
+    // 최대 수용 인원
+    private int capacity;
+
+    // 현재 예약된 인원
+    private int currentCount;
+}

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/repository/ClassScheduleRepository.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/repository/ClassScheduleRepository.java
@@ -1,0 +1,10 @@
+package com._z.eum.onedayClass.classSchedules.repository;
+
+import com._z.eum.onedayClass.classSchedules.entity.ClassSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ClassScheduleRepository extends JpaRepository<ClassSchedule, Integer> {
+    List<ClassSchedule> findByClasses_Id(int classId);
+}

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/repository/ClassScheduleRepository.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/repository/ClassScheduleRepository.java
@@ -3,8 +3,14 @@ package com._z.eum.onedayClass.classSchedules.repository;
 import com._z.eum.onedayClass.classSchedules.entity.ClassSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+
 
 public interface ClassScheduleRepository extends JpaRepository<ClassSchedule, Integer> {
     List<ClassSchedule> findByClasses_Id(int classId);
+
+    //같은 날짜 같은 시간 중복 확인용
+    boolean existsByClasses_IdAndDateAndTimeSlot(int classId, LocalDate date, LocalTime timeSlot);
 }

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/service/ClassScheduleService.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/service/ClassScheduleService.java
@@ -23,6 +23,11 @@ public class ClassScheduleService {
         Classes classes = classesRepository.findById(dto.classId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 클래스가 존재하지 않습니다."));
 
+        // 중복 체크
+        if (classScheduleRepository.existsByClasses_IdAndDateAndTimeSlot(dto.classId(), dto.date(), dto.timeSlot())) {
+            throw new IllegalArgumentException("해당 클래스에 동일한 날짜와 시간의 일정이 이미 존재합니다.");
+        }
+
         ClassSchedule schedule = ClassSchedule.builder()
                 .classes(classes)
                 .date(dto.date())
@@ -62,6 +67,16 @@ public class ClassScheduleService {
 
         Classes classes = classesRepository.findById(dto.classId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 클래스가 존재하지 않습니다."));
+
+        // 중복 체크
+        boolean existsDuplicate = classScheduleRepository
+                .existsByClasses_IdAndDateAndTimeSlot(dto.classId(), dto.date(), dto.timeSlot());
+
+        if (existsDuplicate && !(schedule.getClasses().getId() == dto.classId()
+                && schedule.getDate().equals(dto.date())
+                && schedule.getTimeSlot().equals(dto.timeSlot()))) {
+            throw new IllegalArgumentException("해당 클래스에 동일한 날짜와 시간의 일정이 이미 존재합니다.");
+        }
 
         schedule.setClasses(classes);
         schedule.setDate(dto.date());

--- a/src/main/java/com/_z/eum/onedayClass/classSchedules/service/ClassScheduleService.java
+++ b/src/main/java/com/_z/eum/onedayClass/classSchedules/service/ClassScheduleService.java
@@ -1,0 +1,93 @@
+package com._z.eum.onedayClass.classSchedules.service;
+
+import com._z.eum.onedayClass.classSchedules.dto.request.ClassScheduleRequest;
+import com._z.eum.onedayClass.classSchedules.dto.response.ClassScheduleResponse;
+import com._z.eum.onedayClass.classSchedules.entity.ClassSchedule;
+import com._z.eum.onedayClass.classSchedules.repository.ClassScheduleRepository;
+import com._z.eum.onedayClass.classes.entity.Classes;
+import com._z.eum.onedayClass.classes.repository.ClassesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClassScheduleService {
+
+    private final ClassScheduleRepository classScheduleRepository;
+    private final ClassesRepository classesRepository;
+
+    // 일정 생성
+    public ClassScheduleResponse createSchedule(ClassScheduleRequest dto) {
+        Classes classes = classesRepository.findById(dto.classId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 클래스가 존재하지 않습니다."));
+
+        ClassSchedule schedule = ClassSchedule.builder()
+                .classes(classes)
+                .date(dto.date())
+                .timeSlot(dto.timeSlot())
+                .capacity(dto.capacity())
+                .currentCount(dto.currentCount())
+                .build();
+
+        return toResponse(classScheduleRepository.save(schedule));
+    }
+
+    // 전체 일정 조회
+    public List<ClassScheduleResponse> getAllSchedules() {
+        return classScheduleRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // 특정 클래스 일정 전체 조회
+    public List<ClassScheduleResponse> getSchedulesByClass(int classId) {
+        return classScheduleRepository.findByClasses_Id(classId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // 단일 일정 조회
+    public ClassScheduleResponse getSchedule(int id) {
+        ClassSchedule schedule = classScheduleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정이 존재하지 않습니다."));
+        return toResponse(schedule);
+    }
+
+    // 일정 수정
+    public ClassScheduleResponse updateSchedule(int id, ClassScheduleRequest dto) {
+        ClassSchedule schedule = classScheduleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정이 존재하지 않습니다."));
+
+        Classes classes = classesRepository.findById(dto.classId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 클래스가 존재하지 않습니다."));
+
+        schedule.setClasses(classes);
+        schedule.setDate(dto.date());
+        schedule.setTimeSlot(dto.timeSlot());
+        schedule.setCapacity(dto.capacity());
+        schedule.setCurrentCount(dto.currentCount());
+
+        return toResponse(classScheduleRepository.save(schedule));
+    }
+
+    // 일정 삭제
+    public void deleteSchedule(int id) {
+        if (!classScheduleRepository.existsById(id)) {
+            throw new IllegalArgumentException("해당 일정이 존재하지 않습니다.");
+        }
+        classScheduleRepository.deleteById(id);
+    }
+
+    private ClassScheduleResponse toResponse(ClassSchedule entity) {
+        return new ClassScheduleResponse(
+                entity.getId(),
+                entity.getClasses().getId(),
+                entity.getDate(),
+                entity.getTimeSlot(),
+                entity.getCapacity(),
+                entity.getCurrentCount()
+        );
+    }
+}

--- a/src/main/java/com/_z/eum/onedayClass/classes/controller/ClassesController.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/controller/ClassesController.java
@@ -1,0 +1,62 @@
+package com._z.eum.onedayClass.classes.controller;
+
+import com._z.eum.onedayClass.classes.dto.request.ClassesRequest;
+import com._z.eum.onedayClass.classes.dto.response.ClassesResponse;
+import com._z.eum.onedayClass.classes.service.ClassesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/classes")
+@Tag(name = "원데이 클래스 API", description = "클래스 등록, 조회, 수정, 삭제 기능 제공")
+public class ClassesController {
+
+    private final ClassesService classesService;
+
+    public ClassesController(ClassesService classesService) {
+        this.classesService = classesService;
+    }
+
+    // 전체 클래스 조회
+    @GetMapping("/all")
+    @Operation(summary = "전체 클래스 조회", description = "저장된 모든 클래스 정보 조회")
+    public ResponseEntity<List<ClassesResponse>> getAllClasses() {
+        return ResponseEntity.ok(classesService.getAllClasses());
+    }
+
+    // 단일 클래스 조회
+    @GetMapping("/{id}")
+    @Operation(summary = "클래스 단일 조회", description = "클래스 ID로 특정 클래스 정보 조회")
+    public ResponseEntity<ClassesResponse> getClassById(@PathVariable Integer id) {
+        return ResponseEntity.ok(classesService.getClassById(id));
+    }
+
+    // 클래스 생성
+    @PostMapping
+    @Operation(summary = "클래스 등록", description = "새로운 원데이 클래스를 등록")
+    public ResponseEntity<ClassesResponse> createClass(@RequestBody ClassesRequest request) {
+        return ResponseEntity.ok(classesService.createClass(request));
+    }
+
+    // 클래스 수정
+    @PutMapping("/{id}")
+    @Operation(summary = "클래스 수정", description = "클래스 ID를 기준으로 클래스 정보를 수정")
+    public ResponseEntity<ClassesResponse> updateClass(
+            @PathVariable Integer id,
+            @RequestBody ClassesRequest request
+    ) {
+        return ResponseEntity.ok(classesService.updateClass(id, request));
+    }
+
+    // 클래스 삭제
+    @DeleteMapping("/{id}")
+    @Operation(summary = "클래스 삭제", description = "클래스 ID를 기준으로 클래스 삭제")
+    public ResponseEntity<String> deleteClass(@PathVariable Integer id) {
+        classesService.deleteClass(id);
+        return ResponseEntity.ok("클래스 삭제 성공했습니다.");
+    }
+}

--- a/src/main/java/com/_z/eum/onedayClass/classes/dto/request/ClassesRequest.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/dto/request/ClassesRequest.java
@@ -4,13 +4,28 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "클래스 생성, 수정 요청 DTO")
 public record ClassesRequest(
+
+        @Schema(description = "기술 카테고리", example = "1")
         int skillId,
+
+        @Schema(description = "기술 장인", example = "1")
         int artisanId,
+
+        @Schema(description = "클래스 이름", example = "목공 기초 — 선반 만들기")
         String title,
+
+        @Schema(description = "클래스 사진", example = "example.com")
         String photoUrl,
+
+        @Schema(description = "클래스 설명", example = "목공 기초 — 선반 만들기는 목공 기초부터 시작하여 선반을 만드는 아주아주 재밌는 원데이 클래스입니다.")
         String description,
+
+        @Schema(description = "클래스 가격", example = "56,000")
         int price,
+
+        @Schema(description = "클래스 위치", example = "서울특별시 광진구")
         String location,
-        int capacity,
-        int interestedCount
+
+        @Schema(description = "클래스 최대 수용 인원", example = "12")
+        int capacity
 ) {}

--- a/src/main/java/com/_z/eum/onedayClass/classes/dto/request/ClassesRequest.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/dto/request/ClassesRequest.java
@@ -1,0 +1,16 @@
+package com._z.eum.onedayClass.classes.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "클래스 생성, 수정 요청 DTO")
+public record ClassesRequest(
+        int skillId,
+        int artisanId,
+        String title,
+        String photoUrl,
+        String description,
+        int price,
+        String location,
+        int capacity,
+        int interestedCount
+) {}

--- a/src/main/java/com/_z/eum/onedayClass/classes/dto/request/ClassesRequest.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/dto/request/ClassesRequest.java
@@ -20,7 +20,7 @@ public record ClassesRequest(
         @Schema(description = "클래스 설명", example = "목공 기초 — 선반 만들기는 목공 기초부터 시작하여 선반을 만드는 아주아주 재밌는 원데이 클래스입니다.")
         String description,
 
-        @Schema(description = "클래스 가격", example = "56,000")
+        @Schema(description = "클래스 가격", example = "56000")
         int price,
 
         @Schema(description = "클래스 위치", example = "서울특별시 광진구")

--- a/src/main/java/com/_z/eum/onedayClass/classes/dto/response/ClassesResponse.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/dto/response/ClassesResponse.java
@@ -1,0 +1,17 @@
+package com._z.eum.onedayClass.classes.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "클래스 정보 응답 DTO")
+public record ClassesResponse(
+        int id,
+        int skillId,
+        int artisanId,
+        String title,
+        String photoUrl,
+        String description,
+        int price,
+        String location,
+        int capacity,
+        int interestedCount
+) {}

--- a/src/main/java/com/_z/eum/onedayClass/classes/entity/Classes.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/entity/Classes.java
@@ -1,0 +1,34 @@
+package com._z.eum.onedayClass.classes.entity;
+
+import com._z.eum.skill.entity.SkillCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "classes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Classes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "artisan_id", nullable = false)
+    private int artisanId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "skill_id", nullable = false)
+    private SkillCategory skillCategory;
+
+    private String title;
+    private String photoUrl;
+    private String description;
+    private int price;
+    private String location;
+    private int capacity;
+    private int interestedCount;
+}

--- a/src/main/java/com/_z/eum/onedayClass/classes/repository/ClassesRepository.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/repository/ClassesRepository.java
@@ -1,0 +1,7 @@
+package com._z.eum.onedayClass.classes.repository;
+
+import com._z.eum.onedayClass.classes.entity.Classes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClassesRepository extends JpaRepository<Classes, Integer> {
+}

--- a/src/main/java/com/_z/eum/onedayClass/classes/service/ClassesService.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/service/ClassesService.java
@@ -35,6 +35,8 @@ public class ClassesService {
     // 생성
     public ClassesResponse createClass(ClassesRequest dto) {
         Classes entity = toEntity(dto);
+        // 관심 인원은 항상 0으로 시작
+        entity.setInterestedCount(0);
         return toResponse(classesRepository.save(entity));
     }
 
@@ -54,7 +56,6 @@ public class ClassesService {
         entity.setPrice(dto.price());
         entity.setLocation(dto.location());
         entity.setCapacity(dto.capacity());
-        entity.setInterestedCount(dto.interestedCount());
 
         return toResponse(classesRepository.save(entity));
     }
@@ -95,7 +96,6 @@ public class ClassesService {
                 .price(dto.price())
                 .location(dto.location())
                 .capacity(dto.capacity())
-                .interestedCount(dto.interestedCount())
                 .build();
     }
 }

--- a/src/main/java/com/_z/eum/onedayClass/classes/service/ClassesService.java
+++ b/src/main/java/com/_z/eum/onedayClass/classes/service/ClassesService.java
@@ -1,0 +1,101 @@
+package com._z.eum.onedayClass.classes.service;
+
+import com._z.eum.onedayClass.classes.dto.request.ClassesRequest;
+import com._z.eum.onedayClass.classes.dto.response.ClassesResponse;
+import com._z.eum.onedayClass.classes.entity.Classes;
+import com._z.eum.onedayClass.classes.repository.ClassesRepository;
+import com._z.eum.skill.entity.SkillCategory;
+import com._z.eum.skill.repository.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClassesService {
+
+    private final ClassesRepository classesRepository;
+    private final SkillRepository skillCategoryRepository;
+
+    // 전체 조회
+    public List<ClassesResponse> getAllClasses() {
+        return classesRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // 단건 조회
+    public ClassesResponse getClassById(int id) {
+        return classesRepository.findById(id)
+                .map(this::toResponse)
+                .orElseThrow(() -> new IllegalArgumentException("해당 클래스가 존재하지 않습니다."));
+    }
+
+    // 생성
+    public ClassesResponse createClass(ClassesRequest dto) {
+        Classes entity = toEntity(dto);
+        return toResponse(classesRepository.save(entity));
+    }
+
+    // 수정
+    public ClassesResponse updateClass(int id, ClassesRequest dto) {
+        Classes entity = classesRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 클래스가 존재하지 않습니다."));
+
+        SkillCategory skillCategory = skillCategoryRepository.findById(dto.skillId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 스킬이 존재하지 않습니다."));
+
+        entity.setArtisanId(dto.artisanId());
+        entity.setSkillCategory(skillCategory);
+        entity.setTitle(dto.title());
+        entity.setPhotoUrl(dto.photoUrl());
+        entity.setDescription(dto.description());
+        entity.setPrice(dto.price());
+        entity.setLocation(dto.location());
+        entity.setCapacity(dto.capacity());
+        entity.setInterestedCount(dto.interestedCount());
+
+        return toResponse(classesRepository.save(entity));
+    }
+
+    // 삭제
+    public void deleteClass(int id) {
+        if (!classesRepository.existsById(id)) {
+            throw new IllegalArgumentException("해당 클래스가 존재하지 않습니다.");
+        }
+        classesRepository.deleteById(id);
+    }
+
+    private ClassesResponse toResponse(Classes entity) {
+        return new ClassesResponse(
+                entity.getId(),
+                entity.getSkillCategory() != null ? entity.getSkillCategory().getId() : 0,
+                entity.getArtisanId(),
+                entity.getTitle(),
+                entity.getPhotoUrl(),
+                entity.getDescription(),
+                entity.getPrice(),
+                entity.getLocation(),
+                entity.getCapacity(),
+                entity.getInterestedCount()
+        );
+    }
+
+    private Classes toEntity(ClassesRequest dto) {
+        SkillCategory skillCategory = skillCategoryRepository.findById(dto.skillId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 스킬이 존재하지 않습니다."));
+
+        return Classes.builder()
+                .artisanId(dto.artisanId())
+                .skillCategory(skillCategory)
+                .title(dto.title())
+                .photoUrl(dto.photoUrl())
+                .description(dto.description())
+                .price(dto.price())
+                .location(dto.location())
+                .capacity(dto.capacity())
+                .interestedCount(dto.interestedCount())
+                .build();
+    }
+}

--- a/src/main/java/com/_z/eum/skill/entity/SkillCategory.java
+++ b/src/main/java/com/_z/eum/skill/entity/SkillCategory.java
@@ -13,9 +13,9 @@ public class SkillCategory {
     private int id;
     private String name;
     private  String category;
-    String description;
-    String imageUrl;
-    String careerPath;
+    private String description;
+    private String imageUrl;
+    private String careerPath;
 
     protected SkillCategory(){}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,9 +10,9 @@ spring:
     password:
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect  # H2 맞춤 SQL 생성
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create   # 테이블 새로 생성 (drop 에러 방지)
+      ddl-auto: update
     show-sql: true
 
   mail:


### PR DESCRIPTION
### 📌 PR 제목
> [Feat] 원데이 클래스 관련 API 구현 

---

### ✅ 작업 개요
- 원데이 클래스 기본 정보 CRUD
- 원데이 클래스의 일정 정보 CRUD
- 관련 이슈 번호: Closes #18 


---

### 🔨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| API 추가/변경 | 신규 API 추가, 기존 API 변경 |
| 로직 수정 | 서비스 / 도메인 로직 수정 |
| DB 변경 | 엔티티/테이블/쿼리 변경 포함 |
| 예외 처리 | 예외 핸들링 추가 또는 수정 |
| 테스트 | 테스트 코드 추가/수정 |

---

### 📂 관련 파일 경로
onedayClass
 ├── classes
 │    ├── controller
 │    │    └── ClassesController.java
 │    ├── dto
 │    │    └── ClassesDto.java
 │    ├── entity
 │    │    └── Classes.java
 │    ├── repository
 │    │    └── ClassesRepository.java
 │    └── service
 │         └── ClassesService.java
 │
 └── classSchedules
      ├── controller
      │    └── ClassScheduleController.java
      ├── dto
      │    └── ClassScheduleDto.java
      ├── entity
      │    └── ClassSchedule.java
      ├── repository
      │    └── ClassScheduleRepository.java
      └── service
           └── ClassScheduleService.java


---

### 🧪 테스트 및 검증
- [ ] Postman 또는 Swagger로 직접 테스트 완료  
- [ ] 다른 기능에 영향 없음 확인

---

### 🙋 리뷰 포인트
- Classes(수업 기본정보) 와 ClassSchedule(특정 수업의 일정) 은 1:N 관계

---

### 📎 참고 자료
- <img width="1203" height="303" alt="image" src="https://github.com/user-attachments/assets/a4a04f4c-0a70-469c-bd5a-a0b628708260" />

---


